### PR TITLE
feat: add session isolation for multi-terminal workflows

### DIFF
--- a/docs/manual-session-isolation-testing.md
+++ b/docs/manual-session-isolation-testing.md
@@ -1,0 +1,234 @@
+# Session Isolation Testing Guide
+
+This guide walks through testing session isolation with two Claude Code terminals.
+
+## Overview
+
+Session isolation ensures that **task** and **session** tier memories are scoped to individual Claude Code sessions. This prevents cross-contamination when running multiple terminals on the same project.
+
+**What's isolated:**
+- `task` tier: Ephemeral facts for the current task
+- `session` tier: Facts that persist for the session duration
+
+**Note:** This implementation focuses on task/session isolation. Longterm memory features are not currently active.
+
+---
+
+## Prerequisites
+
+### 1. Clone the repository
+
+```bash
+git clone https://github.com/rand/rlm-claude-code.git ~/src/rlm-claude-code
+cd ~/src/rlm-claude-code
+```
+
+### 2. Install dependencies
+
+```bash
+cd ~/src/rlm-claude-code
+uv sync --all-extras --python 3.12
+```
+
+Verify the installation:
+```bash
+.venv/bin/python -c "from src.memory_store import MemoryStore; print('OK')"
+```
+
+### 3. Configure Claude Code hooks
+
+Create or update `~/.claude/hooks.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd /Users/YOUR_USERNAME/src/rlm-claude-code && .venv/bin/python scripts/init_rlm.py",
+            "timeout": 5000,
+            "description": "Initialize RLM environment"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd /Users/YOUR_USERNAME/src/rlm-claude-code && .venv/bin/python scripts/sync_context.py",
+            "timeout": 2000,
+            "description": "Sync tool context with RLM state"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Important:** Replace `YOUR_USERNAME` with your actual username.
+
+### 4. Verify hooks are loaded
+
+Start a new Claude Code session and check for the "RLM initialized" message, or run:
+```bash
+cat ~/.claude/rlm-config.json
+```
+
+---
+
+## Quick Test (Programmatic)
+
+Run this script to verify session isolation works:
+
+```bash
+cd ~/src/rlm-claude-code && .venv/bin/python << 'EOF'
+import tempfile, os
+from src.memory_store import MemoryStore
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    store = MemoryStore(db_path=os.path.join(tmpdir, "test.db"))
+
+    # Terminal A adds a task fact
+    store.add_fact("Working on JWT auth", tier="task",
+                   metadata={"session_id": "terminal-a"})
+
+    # Terminal B adds a task fact
+    store.add_fact("Working on Stripe billing", tier="task",
+                   metadata={"session_id": "terminal-b"})
+
+    # Query from each perspective
+    a_sees = store.query_nodes(tier="task", session_id="terminal-a")
+    b_sees = store.query_nodes(tier="task", session_id="terminal-b")
+
+    print(f"Terminal A sees: {[n.content for n in a_sees]}")
+    print(f"Terminal B sees: {[n.content for n in b_sees]}")
+
+    assert len(a_sees) == 1 and "JWT" in a_sees[0].content
+    assert len(b_sees) == 1 and "Stripe" in b_sees[0].content
+    print("✓ Session isolation working!")
+EOF
+```
+
+---
+
+## Manual Two-Terminal Test
+
+### Setup
+
+Open two terminal windows: **Terminal A** and **Terminal B**.
+
+### Terminal A: Authentication Feature
+
+**Step 1:** Start Claude Code
+```bash
+cd ~/your-project
+claude
+```
+
+**Step 2:** Store task-tier fact
+> "Remember that I'm working on JWT authentication for this task"
+
+**Step 3:** Store session-tier fact
+> "Remember for this session: Auth service uses port 3001"
+
+### Terminal B: Billing Feature
+
+**Step 1:** Start Claude Code (new session)
+```bash
+cd ~/your-project
+claude
+```
+
+**Step 2:** Store task-tier fact
+> "Remember that I'm working on Stripe billing integration"
+
+**Step 3:** Store session-tier fact
+> "Remember for this session: Billing service uses port 3002"
+
+---
+
+## Verification Tests
+
+### Test 1: Task Tier Isolation (Terminal A)
+Ask Claude:
+> "What am I currently working on?"
+
+**Expected:** JWT authentication
+**Should NOT see:** Stripe billing
+
+### Test 2: Task Tier Isolation (Terminal B)
+Ask Claude:
+> "What am I currently working on?"
+
+**Expected:** Stripe billing
+**Should NOT see:** JWT authentication
+
+### Test 3: Session Tier Isolation (Terminal A)
+Ask Claude:
+> "What port does my service use?"
+
+**Expected:** Port 3001
+**Should NOT see:** Port 3002
+
+### Test 4: Session Tier Isolation (Terminal B)
+Ask Claude:
+> "What port does my service use?"
+
+**Expected:** Port 3002
+**Should NOT see:** Port 3001
+
+---
+
+## Expected Results Summary
+
+| Test | Terminal | Query | Expected Result |
+|------|----------|-------|-----------------|
+| Task isolation | A | "What am I working on?" | JWT auth only |
+| Task isolation | B | "What am I working on?" | Stripe billing only |
+| Session isolation | A | "What port?" | 3001 only |
+| Session isolation | B | "What port?" | 3002 only |
+
+---
+
+## Debugging
+
+### Check session ID
+```bash
+echo $CLAUDE_SESSION_ID
+```
+Each terminal should have a different session ID.
+
+### Check stored memories
+```python
+from src.memory_store import MemoryStore
+import os
+
+store = MemoryStore()
+session_id = os.environ.get("CLAUDE_SESSION_ID")
+
+# See this session's task nodes
+task_nodes = store.query_nodes(tier="task", session_id=session_id)
+print(f"Task nodes for this session: {len(task_nodes)}")
+for n in task_nodes:
+    print(f"  - {n.content}")
+
+# See this session's session nodes
+session_nodes = store.query_nodes(tier="session", session_id=session_id)
+print(f"Session nodes: {len(session_nodes)}")
+for n in session_nodes:
+    print(f"  - {n.content}")
+```
+
+### Verify no cross-contamination
+```python
+# Query without session filter (admin view)
+all_nodes = store.query_nodes(tier="task")
+print(f"Total task nodes across all sessions: {len(all_nodes)}")
+```

--- a/docs/session-isolation.md
+++ b/docs/session-isolation.md
@@ -1,0 +1,122 @@
+# Session Isolation for Multi-Terminal Workflows
+
+## Problem
+
+When running multiple Claude Code instances on the same project (e.g., one terminal working on auth, another on billing), memories from different tasks can cross-contaminate. Terminal B might retrieve memories stored by Terminal A, leading to confusion and incorrect context.
+
+## Solution
+
+Session isolation filters `task` and `session` tier memories by `session_id`, ensuring each terminal only sees its own memories. Shared knowledge (`longterm` and `archive` tiers) remains accessible to all sessions.
+
+### Tier Behavior
+
+| Tier | Isolation | Use Case |
+|------|-----------|----------|
+| `task` | Per-session | Current task context, ephemeral |
+| `session` | Per-session | Session-specific learning |
+| `longterm` | Shared | Cross-session knowledge (e.g., "DB runs on port 5432") |
+| `archive` | Shared | Historical reference |
+
+## API Changes
+
+### `MemoryStore.query_nodes()`
+
+New optional parameter:
+
+```python
+def query_nodes(
+    self,
+    node_type: str | None = None,
+    tier: str | None = None,
+    min_confidence: float = 0.0,
+    limit: int = 100,
+    session_id: str | None = None,  # NEW
+    include_archived: bool = False,
+) -> list[Node]:
+```
+
+When `session_id` is provided and tier is `task` or `session`, results are filtered to nodes where `metadata.session_id` matches.
+
+### `ReplEnvironment` Methods
+
+All memory methods now accept optional `session_id`:
+
+```python
+# Storing with session context
+memory_add_fact(content, tier="session", session_id="abc123")
+memory_add_experience(content, outcome, session_id="abc123")
+
+# Querying with session isolation
+memory_query(query, tier="session", session_id="abc123")
+memory_get_context(session_id="abc123")
+```
+
+## Usage
+
+### Storing Session-Scoped Memories
+
+```python
+from rlm import MemoryStore
+
+store = MemoryStore()
+session_id = "session-abc123"  # From Claude Code session
+
+# Store a task-specific fact
+store.add_fact(
+    content="Working on JWT authentication",
+    tier="task",
+    metadata={"session_id": session_id}
+)
+```
+
+### Querying with Isolation
+
+```python
+# Only returns nodes from this session
+results = store.query_nodes(
+    tier="session",
+    session_id=session_id,
+    limit=10
+)
+```
+
+### Storing Shared Knowledge
+
+```python
+# Longterm facts are visible to all sessions
+store.add_fact(
+    content="PostgreSQL runs on port 5432",
+    tier="longterm",
+    metadata={"session_id": session_id}  # Origin tracked, but not filtered
+)
+```
+
+## Implementation Details
+
+Session filtering uses SQLite's `json_extract()` on the existing `metadata` JSON column:
+
+```sql
+SELECT * FROM nodes
+WHERE tier = 'session'
+  AND json_extract(metadata, '$.session_id') = ?
+ORDER BY confidence DESC, last_accessed DESC
+LIMIT ?
+```
+
+This approach requires no schema migration and maintains backward compatibility.
+
+## Backward Compatibility
+
+- `session_id` parameter defaults to `None`
+- When `None`, all nodes are returned (existing behavior)
+- Nodes without `session_id` in metadata remain visible to all sessions
+- No changes required for single-terminal workflows
+
+## Testing
+
+Run session isolation tests:
+
+```bash
+uv run pytest tests/unit/test_session_isolation.py -v
+uv run pytest tests/integration/test_parallel_sessions.py -v
+```

--- a/src/intelligent_orchestrator.py
+++ b/src/intelligent_orchestrator.py
@@ -228,6 +228,7 @@ class IntelligentOrchestrator:
         available_models: list[str] | None = None,
         telemetry: Any | None = None,
         memory_store: MemoryStore | None = None,
+        session_id: str | None = None,
     ):
         """
         Initialize the intelligent orchestrator.
@@ -238,6 +239,7 @@ class IntelligentOrchestrator:
             available_models: List of available model names
             telemetry: Optional OrchestrationTelemetry for heuristic tracking
             memory_store: Optional MemoryStore for memory-augmented orientation
+            session_id: Session ID for memory isolation (task/session tiers)
         """
         self._client = client
         self.config = config or OrchestratorConfig()
@@ -248,6 +250,7 @@ class IntelligentOrchestrator:
         self._decision_logger: Any = None  # Lazy initialized
         self._telemetry = telemetry  # OrchestrationTelemetry for per-heuristic tracking
         self._memory_store = memory_store  # For memory-augmented orientation (SPEC-12.04)
+        self._session_id = session_id  # For memory isolation
         self._stats = {
             "llm_decisions": 0,
             "local_decisions": 0,
@@ -332,6 +335,7 @@ class IntelligentOrchestrator:
                 node_type="experience",
                 tier="session",  # Prioritize recent session experiences
                 limit=3,
+                session_id=self._session_id,  # Session isolation
             )
             for exp in experiences:
                 # Check if experience was successful and has strategy metadata

--- a/tests/integration/test_parallel_sessions.py
+++ b/tests/integration/test_parallel_sessions.py
@@ -1,0 +1,228 @@
+"""Integration tests for parallel session isolation."""
+import pytest
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from src.memory_store import MemoryStore
+
+
+class TestParallelSessions:
+    """Test isolation when multiple sessions run concurrently."""
+
+    @pytest.fixture
+    def shared_store(self, tmp_path):
+        """Create a shared memory store (simulates single DB)."""
+        db_path = tmp_path / "shared_memory.db"
+        return MemoryStore(db_path=str(db_path))
+
+    def test_concurrent_writes_isolated(self, shared_store):
+        """Concurrent sessions writing should not cross-contaminate."""
+        errors = []
+
+        def session_worker(session_id: str, topic: str, store: MemoryStore):
+            try:
+                # Each session writes 20 facts about its topic
+                for i in range(20):
+                    store.create_node(
+                        node_type="fact",
+                        content=f"{topic} fact {i}",
+                        tier="session",
+                        metadata={"session_id": session_id}
+                    )
+                    time.sleep(0.01)  # Simulate real work
+
+                # Verify isolation - should only see own facts
+                results = store.query_nodes(
+                    tier="session",
+                    session_id=session_id,
+                    limit=50
+                )
+
+                for node in results:
+                    if topic not in node.content:
+                        errors.append(
+                            f"Session {session_id} saw foreign content: {node.content}"
+                        )
+            except Exception as e:
+                errors.append(str(e))
+
+        # Run 3 parallel sessions
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            futures = [
+                executor.submit(session_worker, "session-auth", "auth", shared_store),
+                executor.submit(session_worker, "session-billing", "billing", shared_store),
+                executor.submit(session_worker, "session-users", "users", shared_store),
+            ]
+            # Wait for all to complete
+            for future in futures:
+                future.result()
+
+        assert len(errors) == 0, f"Isolation failures: {errors}"
+
+    def test_longterm_visible_to_all_concurrent_sessions(self, shared_store):
+        """Longterm facts should be visible across concurrent sessions."""
+        # Pre-populate longterm knowledge
+        shared_store.create_node(
+            node_type="fact",
+            content="Database runs on port 5432",
+            tier="longterm",
+            metadata={"session_id": "setup"}
+        )
+
+        visible_count = {"count": 0}
+        lock = threading.Lock()
+
+        def check_longterm(session_id: str, store: MemoryStore):
+            results = store.query_nodes(tier="longterm", session_id=session_id)
+            if any("5432" in n.content for n in results):
+                with lock:
+                    visible_count["count"] += 1
+
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            futures = [
+                executor.submit(check_longterm, "session-a", shared_store),
+                executor.submit(check_longterm, "session-b", shared_store),
+                executor.submit(check_longterm, "session-c", shared_store),
+            ]
+            for future in futures:
+                future.result()
+
+        # All 3 sessions should see the longterm fact
+        assert visible_count["count"] == 3
+
+    def test_rapid_concurrent_access(self, shared_store):
+        """Rapid concurrent access should not cause race conditions."""
+        errors = []
+        write_counts = {"session-a": 0, "session-b": 0}
+
+        def rapid_writer(session_id: str, store: MemoryStore, count: int):
+            try:
+                for i in range(count):
+                    store.create_node(
+                        node_type="fact",
+                        content=f"Rapid fact {i} from {session_id}",
+                        tier="task",
+                        metadata={"session_id": session_id}
+                    )
+                write_counts[session_id] = count
+            except Exception as e:
+                errors.append(f"{session_id}: {e}")
+
+        # Two sessions writing rapidly
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(rapid_writer, "session-a", shared_store, 50),
+                executor.submit(rapid_writer, "session-b", shared_store, 50),
+            ]
+            for future in futures:
+                future.result()
+
+        assert len(errors) == 0, f"Race condition errors: {errors}"
+
+        # Verify each session sees correct count
+        results_a = shared_store.query_nodes(tier="task", session_id="session-a", limit=100)
+        results_b = shared_store.query_nodes(tier="task", session_id="session-b", limit=100)
+
+        assert len(results_a) == 50, f"Session A expected 50, got {len(results_a)}"
+        assert len(results_b) == 50, f"Session B expected 50, got {len(results_b)}"
+
+    def test_mixed_tier_concurrent_access(self, shared_store):
+        """Different tiers accessed concurrently should work correctly."""
+        errors = []
+
+        def task_tier_worker(store: MemoryStore):
+            try:
+                for i in range(10):
+                    store.create_node(
+                        node_type="fact",
+                        content=f"Task fact {i}",
+                        tier="task",
+                        metadata={"session_id": "task-session"}
+                    )
+                results = store.query_nodes(tier="task", session_id="task-session")
+                assert len(results) == 10
+            except Exception as e:
+                errors.append(f"task: {e}")
+
+        def longterm_worker(store: MemoryStore):
+            try:
+                for i in range(10):
+                    store.create_node(
+                        node_type="fact",
+                        content=f"Longterm fact {i}",
+                        tier="longterm",
+                        metadata={"session_id": "longterm-session"}
+                    )
+                # Longterm should be visible regardless of session_id
+                results = store.query_nodes(tier="longterm", session_id="any-session")
+                assert len(results) == 10
+            except Exception as e:
+                errors.append(f"longterm: {e}")
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(task_tier_worker, shared_store),
+                executor.submit(longterm_worker, shared_store),
+            ]
+            for future in futures:
+                future.result()
+
+        assert len(errors) == 0, f"Mixed tier errors: {errors}"
+
+
+class TestCrossContaminationPrevention:
+    """Focused tests on preventing cross-contamination between sessions."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        db_path = tmp_path / "test_memory.db"
+        return MemoryStore(db_path=str(db_path))
+
+    def test_no_leakage_between_sessions(self, store):
+        """Facts from one session must never appear in another session's query."""
+        # Create facts for different sessions
+        sessions = ["session-1", "session-2", "session-3"]
+        for session_id in sessions:
+            for i in range(5):
+                store.create_node(
+                    node_type="fact",
+                    content=f"Secret fact {i} for {session_id}",
+                    tier="session",
+                    metadata={"session_id": session_id}
+                )
+
+        # Query each session and verify no cross-contamination
+        for session_id in sessions:
+            results = store.query_nodes(tier="session", session_id=session_id)
+            for node in results:
+                assert session_id in node.content, (
+                    f"Session {session_id} received fact from another session: {node.content}"
+                )
+                # Also verify metadata matches
+                assert node.metadata.get("session_id") == session_id
+
+    def test_session_deletion_does_not_affect_other_sessions(self, store):
+        """Deleting one session's data should not affect others."""
+        # Create facts for two sessions
+        store.create_node(
+            node_type="fact",
+            content="Session A fact",
+            tier="session",
+            metadata={"session_id": "session-a"}
+        )
+        node_b = store.create_node(
+            node_type="fact",
+            content="Session B fact",
+            tier="session",
+            metadata={"session_id": "session-b"}
+        )
+
+        # Delete session A's fact by archiving it
+        results_a = store.query_nodes(tier="session", session_id="session-a")
+        for node in results_a:
+            store.delete_node(node.id)
+
+        # Session B should be unaffected
+        results_b = store.query_nodes(tier="session", session_id="session-b")
+        assert len(results_b) == 1
+        assert results_b[0].content == "Session B fact"

--- a/tests/unit/test_session_isolation.py
+++ b/tests/unit/test_session_isolation.py
@@ -1,0 +1,226 @@
+"""Tests for session isolation in memory store (SPEC-02 extension)."""
+import pytest
+from src.memory_store import MemoryStore
+
+
+class TestSessionIsolation:
+    """Tests for session-scoped memory isolation."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        """Create a memory store with temp database."""
+        db_path = tmp_path / "test_memory.db"
+        return MemoryStore(db_path=str(db_path))
+
+    def test_task_tier_isolated_by_session(self, store):
+        """Task-tier nodes should only be visible to their session."""
+        # Session A stores a fact
+        node_a = store.create_node(
+            node_type="fact",
+            content="Session A working on auth",
+            tier="task",
+            metadata={"session_id": "session-a"}
+        )
+
+        # Session B stores a different fact
+        node_b = store.create_node(
+            node_type="fact",
+            content="Session B working on billing",
+            tier="task",
+            metadata={"session_id": "session-b"}
+        )
+
+        # Query from Session A perspective
+        results_a = store.query_nodes(
+            tier="task",
+            session_id="session-a"
+        )
+
+        # Should only see Session A's node
+        assert len(results_a) == 1
+        assert results_a[0].content == "Session A working on auth"
+
+    def test_session_tier_isolated_by_session(self, store):
+        """Session-tier nodes should only be visible to their session."""
+        store.create_node(
+            node_type="fact",
+            content="Auth uses JWT tokens",
+            tier="session",
+            metadata={"session_id": "session-a"}
+        )
+
+        store.create_node(
+            node_type="fact",
+            content="Billing uses Stripe",
+            tier="session",
+            metadata={"session_id": "session-b"}
+        )
+
+        results_a = store.query_nodes(tier="session", session_id="session-a")
+        results_b = store.query_nodes(tier="session", session_id="session-b")
+
+        assert len(results_a) == 1
+        assert len(results_b) == 1
+        assert results_a[0].content == "Auth uses JWT tokens"
+        assert results_b[0].content == "Billing uses Stripe"
+
+    def test_longterm_tier_shared_across_sessions(self, store):
+        """Longterm-tier nodes should be visible to all sessions."""
+        store.create_node(
+            node_type="fact",
+            content="PostgreSQL runs on port 5433",
+            tier="longterm",
+            metadata={"session_id": "session-a"}  # Origin session
+        )
+
+        # Both sessions should see longterm facts
+        results_a = store.query_nodes(tier="longterm", session_id="session-a")
+        results_b = store.query_nodes(tier="longterm", session_id="session-b")
+
+        assert len(results_a) == 1
+        assert len(results_b) == 1
+
+    def test_archive_tier_shared_across_sessions(self, store):
+        """Archive-tier nodes should be visible to all sessions."""
+        store.create_node(
+            node_type="fact",
+            content="Old API endpoint deprecated",
+            tier="archive",
+            metadata={"session_id": "session-a"}
+        )
+
+        # Need to include_archived to see archive tier
+        results_b = store.query_nodes(
+            tier="archive",
+            session_id="session-b",
+            include_archived=True
+        )
+        assert len(results_b) == 1
+
+    def test_no_session_id_returns_all(self, store):
+        """Query without session_id should return all nodes (backward compatibility)."""
+        store.create_node(
+            node_type="fact",
+            content="Fact from session A",
+            tier="task",
+            metadata={"session_id": "session-a"}
+        )
+        store.create_node(
+            node_type="fact",
+            content="Fact from session B",
+            tier="task",
+            metadata={"session_id": "session-b"}
+        )
+
+        # No session_id filter should return all
+        results = store.query_nodes(tier="task")
+        assert len(results) == 2
+
+    def test_session_id_with_no_matches(self, store):
+        """Query with non-existent session_id should return empty."""
+        store.create_node(
+            node_type="fact",
+            content="Some fact",
+            tier="task",
+            metadata={"session_id": "session-a"}
+        )
+
+        results = store.query_nodes(tier="task", session_id="session-nonexistent")
+        assert len(results) == 0
+
+    def test_nodes_without_session_id_visible_to_all(self, store):
+        """Nodes without session_id in metadata should not match session filters."""
+        # Node without session_id
+        store.create_node(
+            node_type="fact",
+            content="Legacy fact without session",
+            tier="task",
+            metadata={}  # No session_id
+        )
+
+        # Node with session_id
+        store.create_node(
+            node_type="fact",
+            content="New fact with session",
+            tier="task",
+            metadata={"session_id": "session-a"}
+        )
+
+        # Querying with session_id should only return nodes that match
+        results = store.query_nodes(tier="task", session_id="session-a")
+        assert len(results) == 1
+        assert results[0].content == "New fact with session"
+
+        # Querying without session_id should return all
+        all_results = store.query_nodes(tier="task")
+        assert len(all_results) == 2
+
+
+class TestContextVolumeLimits:
+    """Prevent context flooding with too many memories."""
+
+    @pytest.fixture
+    def store(self, tmp_path):
+        db_path = tmp_path / "test_memory.db"
+        return MemoryStore(db_path=str(db_path))
+
+    def test_query_respects_limit(self, store):
+        """Query should respect limit even with many nodes."""
+        # Add 50 nodes
+        for i in range(50):
+            store.create_node(
+                node_type="fact",
+                content=f"Fact number {i}",
+                tier="session",
+                metadata={"session_id": "session-a"}
+            )
+
+        # Query with limit
+        results = store.query_nodes(
+            tier="session",
+            session_id="session-a",
+            limit=10
+        )
+
+        assert len(results) == 10
+
+    def test_query_returns_most_relevant_first(self, store):
+        """Higher confidence nodes should come first."""
+        store.create_node(
+            node_type="fact",
+            content="Low confidence fact",
+            tier="session",
+            confidence=0.3,
+            metadata={"session_id": "session-a"}
+        )
+        store.create_node(
+            node_type="fact",
+            content="High confidence fact",
+            tier="session",
+            confidence=0.9,
+            metadata={"session_id": "session-a"}
+        )
+
+        results = store.query_nodes(
+            tier="session",
+            session_id="session-a",
+            limit=1
+        )
+
+        assert results[0].content == "High confidence fact"
+
+    def test_default_limit_prevents_flooding(self, store):
+        """Default query should not return unlimited results."""
+        # Add 200 nodes
+        for i in range(200):
+            store.create_node(
+                node_type="fact",
+                content=f"Fact {i}",
+                tier="session",
+                metadata={"session_id": "session-a"}
+            )
+
+        results = store.query_nodes(tier="session", session_id="session-a")
+
+        # Should be limited to default (100)
+        assert len(results) <= 100


### PR DESCRIPTION
Thanks for that, I am amazed with the noticeable  increase of perfomance, I didn't had time to benchmark it but I can tell the difference on long tasks, took off all my memory bank patterns and just left that in place. Worked for hours using full subscription token on heavy coding. Running multiple agents with it - that's why I added the session isolation to it.

When running multiple Claude Code instances on the same project, memories from different tasks can cross-contaminate. This adds session isolation to prevent that.

Changes:
- Add session_id parameter to MemoryStore.query_nodes()
- Filter task/session tiers by metadata.session_id
- Keep longterm/archive tiers shared across sessions
- Update REPL functions to propagate session_id
- Add IntelligentOrchestrator session_id support

Testing:
- Unit tests for session isolation behavior
- Integration tests for parallel session stress testing

Documentation:
- docs/session-isolation.md - API guide and usage examples
- docs/manual-session-isolation-testing.md - Manual test procedures

Backward compatible: session_id defaults to None (no filtering).