### PR TITLE
fix: install openssl-devel in manylinux container for CI builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist
           manylinux: auto
+          before-script-linux: yum install -y openssl-devel perl-IPC-Cmd
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- The reqwest crate in rlm-core uses native-tls, which requires OpenSSL dev headers
- The manylinux2014 container lacks these, causing build failures on Linux targets
- Adds `before-script-linux` to install `openssl-devel` and `perl-IPC-Cmd` before the Rust build

Fixes the v0.7.0 release build failure: https://github.com/rand/rlm-claude-code/actions/runs/21613382811

🤖 Generated with [Claude Code](https://claude.com/claude-code)