### PR TITLE
fix plugin marketplace setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ uv run pytest tests/ -v
 
 ```bash
 # Add the marketplace (one-time setup)
-claude plugin marketplace add github:rand/rlm-claude-code
+claude plugin marketplace add [github:rand/rlm-claude-code](https://github.com/rand/rlm-claude-code)
 
 # Install the plugin
 claude plugin install rlm-claude-code@rlm-claude-code


### PR DESCRIPTION
the provided command fails with

```
❌1 ❯ claude plugin marketplace add github:rand/rlm-claude-code

✘ Invalid marketplace source format. Try: owner/repo, https://..., or ./path

❌1 ❯ 
```